### PR TITLE
Able to set request.body as string

### DIFF
--- a/runner.ts
+++ b/runner.ts
@@ -69,6 +69,11 @@ export function CreatePostmanCollectionItemFromStarmanRequest(step: StarmanStep)
             mode: "raw",
             raw: JSON.stringify(step.request.body)
         }
+    } else if (typeof step.request.body === 'string') {
+         step.request.body = {
+            mode: "raw",
+            raw: step.request.body
+        }
     }
 
     const test = toEvents("test", step.test)


### PR DESCRIPTION
Currently, if `request.body` is type `string`, it will not be set to post man. This PR fixes this issue